### PR TITLE
fix multiprocessing with new logs

### DIFF
--- a/runtime/mount/kernel.py
+++ b/runtime/mount/kernel.py
@@ -1320,4 +1320,9 @@ async def main() -> None:
         sys.stderr = old_stderr
 
 
-asyncio.run(main())
+if __name__ == "__main__":
+    import multiprocessing
+
+    multiprocessing.set_start_method("forkserver")
+
+    asyncio.run(main())

--- a/runtime/mount/socketio_thread.py
+++ b/runtime/mount/socketio_thread.py
@@ -16,7 +16,7 @@ class SocketIoThread(Thread):
     conn: SocketIo | None = None
 
     def __init__(self, *, socket: socket) -> None:
-        super().__init__()
+        super().__init__(name="socket_io")
 
         self.socket = socket
         self.shutdown = asyncio.Event()


### PR DESCRIPTION
the default multiprocessing method on Linux is `fork` which has problems and will be replaced by `forkserver` as the default soon anyway

it also doesn't really work with multithreaded processes anyway (apparently)

<img width="754" alt="Screenshot 2024-10-17 at 4 50 43 PM" src="https://github.com/user-attachments/assets/40bd86cb-76ee-4369-a9c3-b79786170d5e">
